### PR TITLE
Updates to reflect reality of initial visitplanid

### DIFF
--- a/referral_state_transitions.sql
+++ b/referral_state_transitions.sql
@@ -1,92 +1,82 @@
-with "childDetailsRaw" AS
-(
+WITH "childDetailsRaw" AS (
 SELECT
-  sr.id
-	,json_array_elements("childDetails")->>'childFamlinkPersonID' id_prsn_child
-	,json_array_elements("childDetails")->>'childOpd' original_placement_date_dirty
-FROM staging."ServiceReferrals" sr
-WHERE "requestDate" BETWEEN '2019-10-01'
-		AND now()
-	AND "formVersion" = 'Ingested'
-	AND "organizationId" != 1
-), "parentDetailsRaw" AS
-(
+    id,
+    json_array_elements("childDetails") ->> 'childFamlinkPersonID' id_prsn_child,
+    json_array_elements("childDetails") ->> 'childOpd' original_placement_date_dirty
+FROM staging. "ServiceReferrals"
+WHERE
+    "requestDate" BETWEEN '2019-10-01' AND now()
+    AND "formVersion" = 'Ingested'
+    AND "organizationId" != 1
+), "parentDetailsRaw" AS (
 SELECT
-  sr.id
-  ,json_array_elements("parentGuardianDetails")->>'parentGuardianId' id_prsn_parent
-FROM staging."ServiceReferrals" sr
-WHERE "requestDate" BETWEEN '2019-10-01'
-		AND now()
-	AND "formVersion" = 'Ingested'
-	AND "organizationId" != 1
-), "childDetails" AS
-(
+    id,
+    json_array_elements("parentGuardianDetails") ->> 'parentGuardianId' id_prsn_parent
+FROM staging. "ServiceReferrals"
+WHERE
+    "requestDate" BETWEEN '2019-10-01'
+    AND now()
+    AND "formVersion" = 'Ingested'
+    AND "organizationId" != 1
+), "childDetails" AS (
 SELECT DISTINCT
-  c1.id
-  ,CASE
-    WHEN id_prsn_child IS NOT NULL
-    THEN id_prsn_child
-    ELSE 0::TEXT
-  END id_prsn_child
-	,CASE
-	  WHEN original_placement_date_dirty ~* '-'
-	  THEN TO_DATE(original_placement_date_dirty, 'YYYY-MM-DD')
-	  WHEN original_placement_date_dirty ~* '/'
-	  THEN TO_DATE(original_placement_date_dirty, 'MM/DD/YYYY')
-	 END AS original_placement_date
-FROM "childDetailsRaw" c1
-), "parentDetails" AS
-(
+    id,
+    CASE WHEN id_prsn_child IS NOT NULL THEN
+        id_prsn_child
+    ELSE
+        0::TEXT
+    END id_prsn_child,
+    CASE WHEN original_placement_date_dirty ~* '-' THEN
+        TO_DATE(original_placement_date_dirty, 'YYYY-MM-DD')
+    WHEN original_placement_date_dirty ~* '/' THEN
+        TO_DATE(original_placement_date_dirty, 'MM/DD/YYYY')
+    END AS original_placement_date
+FROM "childDetailsRaw"
+), "parentDetails" AS (
 SELECT DISTINCT
-  c1.id
-  ,CASE
-    WHEN id_prsn_parent::INTEGER IS NOT NULL
-    THEN id_prsn_parent
-    ELSE 0::TEXT
-  END id_prsn_parent
-FROM "parentDetailsRaw" c1
-), "childAndParentDetails" as
-(
+    id,
+    CASE WHEN id_prsn_parent::INTEGER IS NOT NULL THEN
+        id_prsn_parent
+    ELSE
+        0::TEXT
+    END id_prsn_parent
+FROM "parentDetailsRaw"
+), "childAndParentDetails" AS (
 SELECT
-  sr.id
-  ,sr."caseNumber"
-  ,COALESCE(id_prsn_child, 0::TEXT) id_prsn_child
-  ,COALESCE(id_prsn_parent, 0::TEXT) id_prsn_parent
-  ,original_placement_date
-	 ,DENSE_RANK ()
-	  OVER (
-      ORDER BY
-        COALESCE(id_prsn_child, 0::TEXT)
-        ,sr."caseNumber"
-        ,COALESCE(id_prsn_parent, 0::TEXT)
-   ) visitation_group
-FROM staging."ServiceReferrals" sr
-  LEFT JOIN "childDetails" cr
-    on sr.id = cr.id
-  LEFT JOIN "parentDetails" pr
-    on pr.id = cr.id
+    sr.id,
+    sr."caseNumber" id_case,
+    COALESCE(id_prsn_child, 0::TEXT) id_prsn_child,
+    COALESCE(id_prsn_parent, 0::TEXT) id_prsn_parent,
+    original_placement_date,
+    DENSE_RANK() OVER (ORDER BY
+        COALESCE(id_prsn_child, 0::TEXT),
+        sr."caseNumber",
+        COALESCE(id_prsn_parent, 0::TEXT)) visitation_group
+FROM staging. "ServiceReferrals" sr
+  LEFT JOIN "childDetails" cd
+    ON sr.id = cd.id
+  LEFT JOIN "parentDetails" pd
+    ON pd.id = cd.id
 )
 
-
-SELECT DISTINCT
-  sr.id
-  ,CASE
-		WHEN sr."initialVisitPlanId" = 0
-			THEN sr."visitPlanId"::INTEGER
-		ELSE sr."initialVisitPlanId"
+SELECT DISTINCT CASE
+		WHEN "initialVisitPlanId" = 0
+			THEN "visitPlanId"::INTEGER
+		ELSE "initialVisitPlanId"
 		END AS "initialVisitPlanId"
-	,sr."visitPlanId"
-	,cpd.original_placement_date
-	,cpd.id_prsn_child
-	,cpd.id_prsn_parent
-	,cpd.visitation_group
+	,"visitPlanId"
+  ,id_case
+  ,id_prsn_child
+  ,id_prsn_parent
+  ,original_placement_date
+  ,visitation_group
 	,NULL::INTEGER AS "organizationId"
 	,"requestDate" AS "date"
 	,'visitation_needed' AS "from"
 	,'sw_request' AS "to"
 FROM staging."ServiceReferrals" AS sr
-  LEFT JOIN "childAndParentDetails" cpd
-    ON sr.id = cpd.id
+  LEFT JOIN "childAndParentDetails" cd
+    ON sr.id = cd.id
 WHERE "requestDate" BETWEEN '2019-10-01'
 		AND now()
 	AND "formVersion" = 'Ingested'
@@ -94,25 +84,24 @@ WHERE "requestDate" BETWEEN '2019-10-01'
 
 UNION
 
-SELECT DISTINCT
-  sr.id
-  ,CASE
+SELECT DISTINCT CASE
 		WHEN "initialVisitPlanId" = 0
 			THEN "visitPlanId"::INTEGER
 		ELSE "initialVisitPlanId"
 		END AS "initialVisitPlanId"
 	,"visitPlanId"
-	,cpd.original_placement_date
-	,cpd.id_prsn_child
-	,cpd.id_prsn_parent
-	,cpd.visitation_group
+  ,id_case
+  ,id_prsn_child
+  ,id_prsn_parent
+  ,original_placement_date
+  ,visitation_group
 	,NULL::INTEGER AS "organizationId"
 	,"visitPlanApprovedDate" AS "date"
 	,'sw_request' AS "from"
 	,'approved' AS "to"
 FROM staging."ServiceReferrals" AS sr
-  LEFT JOIN "childAndParentDetails" cpd
-    ON sr.id = cpd.id
+  LEFT JOIN "childAndParentDetails" cd
+    ON sr.id = cd.id
 WHERE "requestDate" BETWEEN '2019-10-01'
 		AND now()
 	AND "formVersion" = 'Ingested'
@@ -120,18 +109,17 @@ WHERE "requestDate" BETWEEN '2019-10-01'
 
 UNION
 
-SELECT
-  sr.id
-  ,CASE
+SELECT CASE
 		WHEN "initialVisitPlanId" = 0
 			THEN "visitPlanId"::INTEGER
 		ELSE "initialVisitPlanId"
 		END AS "initialVisitPlanId"
 	,"visitPlanId"
-	,cpd.original_placement_date
-	,cpd.id_prsn_child
-	,cpd.id_prsn_parent
-	,cpd.visitation_group
+  ,id_case
+  ,id_prsn_child
+  ,id_prsn_parent
+  ,original_placement_date
+  ,visitation_group
 	,"organizationId"
 	,min(sr."updatedAt") AS "date"
 	,'approved' AS "from"
@@ -139,8 +127,8 @@ SELECT
 FROM staging."ServiceReferrals" AS sr
   LEFT JOIN staging."Organizations" AS o
     ON sr."organizationId" = o.id
-  LEFT JOIN "childAndParentDetails" cpd
-    ON sr.id = cpd.id
+  LEFT JOIN "childAndParentDetails" cd
+    ON sr.id = cd.id
 WHERE "requestDate" BETWEEN '2019-10-01'
 		AND now()
 	AND "formVersion" = 'Ingested'
@@ -150,32 +138,28 @@ WHERE "requestDate" BETWEEN '2019-10-01'
 		FROM staging."Organizations"
 		WHERE "routingOrg"
 		)
-	AND (
-		"initialVisitPlanId" = 1174068
-		OR "visitPlanId" = '1174068'
-		)
-GROUP BY sr.id, "initialVisitPlanId"
+GROUP BY "initialVisitPlanId"
 	,"visitPlanId"
 	,"organizationId"
-	,cpd.original_placement_date
-	,cpd.id_prsn_child
-	,cpd.id_prsn_parent
-	,cpd.visitation_group
+  ,id_case
+  ,id_prsn_child
+  ,id_prsn_parent
+  ,original_placement_date
+  ,visitation_group
 
 UNION
 
-SELECT DISTINCT
-  sr.id
-  ,CASE
+SELECT DISTINCT CASE
 		WHEN "initialVisitPlanId" = 0
 			THEN "visitPlanId"::INTEGER
 		ELSE "initialVisitPlanId"
 		END AS "initialVisitPlanId"
 	,"visitPlanId"
-	,cpd.original_placement_date
-	,cpd.id_prsn_child
-	,cpd.id_prsn_parent
-	,cpd.visitation_group
+  ,id_case
+  ,id_prsn_child
+  ,id_prsn_parent
+  ,original_placement_date
+  ,visitation_group
 	,"OrganizationId"
 	,DATE
 	,CASE
@@ -210,6 +194,8 @@ SELECT DISTINCT
 		ELSE ''
 		END AS "to"
 FROM staging."ServiceReferrals" AS sr
+  LEFT JOIN "childAndParentDetails" cd
+    ON sr.id = cd.id
 LEFT JOIN (
 	SELECT "ServiceReferralId"
 		,"StageTypeId"
@@ -220,8 +206,6 @@ LEFT JOIN (
 		,"StageTypeId"
 		,"OrganizationId"
 	) AS srts ON sr.id = srts."ServiceReferralId"
-LEFT JOIN "childAndParentDetails" cpd
-  ON sr.id = cpd.id
 WHERE "requestDate" BETWEEN '2019-10-01'
 		AND now()
 	AND "formVersion" = 'Ingested'
@@ -229,25 +213,92 @@ WHERE "requestDate" BETWEEN '2019-10-01'
 
 UNION
 
-SELECT
-  sr.id
-  ,CASE
+SELECT "initialVisitPlanId"
+	,"visitPlanId"
+  ,id_case
+  ,id_prsn_child
+  ,id_prsn_parent
+  ,original_placement_date
+  ,visitation_group
+	,"organizationId"
+	,"updatedAt" AS DATE
+	,'vc_received_timeline' AS FROM
+	,'vc_received' AS TO
+FROM (
+	SELECT "initialVisitPlanId"
+		,"visitPlanId"
+    ,id_case
+    ,id_prsn_child
+    ,id_prsn_parent
+    ,original_placement_date
+    ,visitation_group
+		,"organizationId"
+		,"updatedAt"
+		,"routingOrg"
+		,LEAD("organizationId", 1, NULL) OVER (
+			PARTITION BY "initialVisitPlanId" ORDER BY "versionId"
+			) AS lead_org
+		,CASE
+			WHEN "routingOrg" IS NOT NULL
+				AND LEAD("routingOrg", 1, NULL) OVER (
+					PARTITION BY "initialVisitPlanId" ORDER BY "versionId"
+					) IS NOT NULL
+				THEN CASE
+						WHEN "organizationId" != LEAD("organizationId", 1, NULL) OVER (
+								PARTITION BY "initialVisitPlanId" ORDER BY "versionId"
+								)
+							THEN 1
+						END
+			END new_org
+	FROM (
+		SELECT "versionId"
+			,CASE
+				WHEN "initialVisitPlanId" = 0
+					THEN "visitPlanId"::INTEGER
+				ELSE "initialVisitPlanId"
+				END AS "initialVisitPlanId"
+			,"visitPlanId"
+      ,id_case
+      ,id_prsn_child
+      ,id_prsn_parent
+      ,original_placement_date
+      ,visitation_group
+			,"organizationId"
+			,sr."updatedAt"
+			,o."routingOrg"
+		FROM staging."ServiceReferrals" AS sr
+		LEFT JOIN staging."Organizations" AS o ON o.id = sr."organizationId"
+			AND o."routingOrg"
+		LEFT JOIN "childAndParentDetails" cd
+    ON sr.id = cd.id
+		WHERE "requestDate" BETWEEN '2019-10-01'
+				AND now()
+			AND "formVersion" = 'Ingested'
+			AND "organizationId" != 1
+		) AS new_ro
+	) AS dat
+WHERE new_org = 1
+
+UNION
+
+SELECT CASE
 		WHEN "initialVisitPlanId" = 0
 			THEN "visitPlanId"::INTEGER
 		ELSE "initialVisitPlanId"
-	END AS "initialVisitPlanId"
+		END AS "initialVisitPlanId"
 	,"visitPlanId"
-	,cpd.original_placement_date
-	,cpd.id_prsn_child
-	,cpd.id_prsn_parent
-	,cpd.visitation_group
+  ,id_case
+  ,id_prsn_child
+  ,id_prsn_parent
+  ,original_placement_date
+  ,visitation_group
 	,"organizationId"
 	,"deletedAt" AS "date"
 	,'vc_received_timeline' AS "from"
 	,'deleted' AS "to"
 FROM staging."ServiceReferrals" sr
-  LEFT JOIN "childAndParentDetails" cpd
-    ON sr.id = cpd.id
+  LEFT JOIN "childAndParentDetails" cd
+    ON sr.id = cd.id
 WHERE "requestDate" BETWEEN '2019-10-01'
 		AND now()
 	AND "formVersion" = 'Ingested'

--- a/referral_state_transitions.sql
+++ b/referral_state_transitions.sql
@@ -220,13 +220,10 @@ SELECT "initialVisitPlanId"
   ,id_prsn_parent
   ,original_placement_date
   ,visitation_group
-	,"organizationId"
-	,"updatedAt" AS DATE
-	,'vc_received_timeline' AS FROM
-	,"organizationId"
-	,"updatedAt" AS DATE
-	,'vc_received_timeline' AS TO
-FROM
+  ,"organizationId"
+  ,"updatedAt" AS DATE
+  ,'vc_received_timeline' AS 'from'
+  ,'vc_received_timeline' AS 'to'
 FROM (
 	SELECT "initialVisitPlanId"
 		,"visitPlanId"


### PR DESCRIPTION
Speaking with Jessy at DCYF yesterday, I learned that the `initialVisitPlanId` only follows the
`visitPlanId` if a worker creates a visit plan by copying a prior visit plan. This will not always happen
and will lead to inconsistent grouping of visit plans for combinations of children and parents.

I've updated the working script here to help with this as follows:

1. Added 2 CTES to define `childAndParentDetails` which specifically include
-- * id - Sprout ServiceReferral ID
-- * id_prsn_child - FamLink Person ID for a child
-- * id_prsn_parent- FamLink Person ID for a parent
-- * original_placement_date - The OPD from the visit plan
-- * visitation_group - to make up for the note mentioned above, a dense ranking of id_prsn_child, and id_prsn_parent
-- * caseNumber - for potential partitioning later on

2. Added a join to the second CTE (childAndParentDetail) to each of the unioned subqueries.

3. Added `id` to the `UNION` expression for reference purposes.